### PR TITLE
Check Buffer at runtime to avoid browserify shims

### DIFF
--- a/objectid.js
+++ b/objectid.js
@@ -2,7 +2,9 @@
 var MACHINE_ID = parseInt(Math.random() * 0xFFFFFF, 10);
 var index = ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
 var pid = typeof process === 'undefined' ? Math.floor(Math.random() * 100000) : process.pid % 0xFFFF;
-var isBuffer = typeof Buffer !== "undefined"? Buffer.isBuffer : function(){};
+var isBuffer = function( obj ) {
+  return typeof Buffer !== "undefined" && Buffer.isBuffer( obj );
+};
 
 /**
  * Create a new immutable ObjectID instance


### PR DESCRIPTION
If we check for Buffer at runtime, browserify won't pull in its core buffer implementation, saving ~40K or so.
